### PR TITLE
Git Interface and Backend Overhaul

### DIFF
--- a/packages/main/src/GitService.ts
+++ b/packages/main/src/GitService.ts
@@ -6,7 +6,62 @@ import { spawn } from 'child_process';
 
 const PATH = require('path');
 
+
 export const GitService = {
+  queue: [],
+  processing: false,
+
+  process: ()=>{
+    if(GitService.queue.length<1){
+      GitService.processing = false;
+      return;
+    }
+
+    const [args,o,resolve] = GitService.queue.pop();
+
+    // console.log('git',args);
+
+    let window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+    window.webContents.send('GitService.MSG', 'git '+args.join(' '));
+
+    try {
+      const p = spawn('git', args, o);
+
+      let error = false;
+      let output = '';
+      const handleOutput = data => {
+        if(!data) return;
+        let dataAsString = data.toString();
+        dataAsString = dataAsString.replace(/\n|\r/g, '\n');
+
+        output += dataAsString;
+        if(dataAsString.toLowerCase().includes('error'))
+          error = true;
+
+        for(let row of dataAsString.split('\n')){
+          if(row==='') continue;
+          window.webContents.send('GitService.MSG', row);
+        }
+      };
+      p.stdout.on('data', handleOutput);
+      p.stderr.on('data', handleOutput);
+
+      // This hits when the child process cannot be spawned
+      p.on('error', err => {
+          console.error("[Git spawn error]", err.toString());
+          resolve([false, err.toString()]);
+          GitService.process();
+      });
+      // This hits whenever process can be spawned, can still fail or resolve.
+      p.on('exit', code => {
+        resolve([code===0 && !error,output]);
+        GitService.process();
+      });
+    } catch (e){
+      resolve([false,e]);
+      GitService.process();
+    }
+  },
 
   run: (e,options) => {
 
@@ -15,11 +70,7 @@ export const GitService = {
       const o = typeof options === 'string' ? {} : options;
       o.env = Object.assign({}, o.env || {}, process.env);
 
-      // console.log(process.env['PATH']);
       o.cwd = (o.cwd || '').split('/').join(PATH.sep);
-
-      let window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
-      window.webContents.send('GitService.MSG', 'git '+args.join(' '));
 
       // o.env['GIT_TRACE'] = 1;
       // o.env['GIT_TRACE_PACKET'] = 1;
@@ -29,39 +80,10 @@ export const GitService = {
       // o.env['GIT_TRANSFER_TRACE'] = 1;
       // o.stdio = 'inherit';
 
-      try {
-        const p = spawn('git', args, o);
-
-        let error = false;
-        let output = '';
-        const handleOutput = data => {
-          if(!data) return;
-          let dataAsString = data.toString();
-          dataAsString = dataAsString.replace(/\n|\r/g, '\n');
-
-          output += dataAsString;
-          if(dataAsString.toLowerCase().includes('error'))
-            error = true;
-
-          for(let row of dataAsString.split('\n')){
-            if(row==='') continue;
-            window.webContents.send('GitService.MSG', row);
-          }
-        };
-        p.stdout.on('data', handleOutput);
-        p.stderr.on('data', handleOutput);
-
-        // This hits when the child process cannot be spawned
-        p.on('error', err => {
-            console.error("[Git spawn error]", err.toString());
-            resolve([false, err.toString()]);
-        });
-        // This hits whenever process can be spawned, can still fail or resolve.
-        p.on('exit', code => {
-          resolve([code===0 && !error,output]);
-        });
-      } catch (e){
-        resolve([false,e]);
+      GitService.queue.push([args, o, resolve]);
+      if(!GitService.processing){
+        GitService.processing = true;
+        GitService.process();
       }
     });
   },

--- a/packages/main/src/LocalFileSystemService.ts
+++ b/packages/main/src/LocalFileSystemService.ts
@@ -127,22 +127,19 @@ export const LocalFileSystemService = {
     const listener = chokidar.watch(path,{ignoreInitial:true, usePolling: os.platform()==='win32'});
     changeListeners.set(path, listener);
 
-    const updatePath = path => {
+    const updatePath = (path,type) => {
       const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
-      window?.webContents.send('LocalFileSystemService.updatePath', path_to_arcitect(path));
-    };
-    const updateParentPath = path => {
-      updatePath( PATH.dirname(path) );
+      window?.webContents.send('LocalFileSystemService.updatePath', [path_to_arcitect(path),type]);
     };
 
     listener
+      .on('add', path=>updatePath(path,'file_add'))
+      .on('unlink', path=>updatePath(path,'file_rm'))
+      .on('addDir', path=>updatePath(path,'dir_add'))
+      .on('unlinkDir', path=>updatePath(path,'dir_rm'))
       // .on('all', (event, path) => {
       //   // console.log(event,path);
       // })
-      .on('add', updateParentPath)
-      .on('unlink', updateParentPath)
-      .on('addDir', updateParentPath)
-      .on('unlinkDir', updateParentPath)
     ;
 
     return;

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -27,6 +27,7 @@ const ALLOWED_EXTERNAL_ORIGINS = new Set<`https://${string}`>([
   'https://www.w3schools.com',
   'https://www.google.com',
   'https://git.nfdi4plants.org',
+  'https://gitlab.nfdi4plants.de',
   'https://gitlab.plantmicrobe.de',
 ]);
 

--- a/packages/renderer/src/App.vue
+++ b/packages/renderer/src/App.vue
@@ -139,12 +139,10 @@ const test = async ()=>{
 
           <q-separator />
 
-          <!--<ToolbarButton text='Upload ARC' icon='cloud_upload' requiresARC='true' @clicked='test()'></ToolbarButton>-->
-          <ToolbarButton text='Refresh ARC' icon='autorenew' requiresARC @clicked='refreshLocalArc()'></ToolbarButton>
-          <ToolbarButton text='Versions' icon='update' requiresARC @clicked='AppProperties.state=AppProperties.STATES.GIT'></ToolbarButton>
+          <ToolbarButton text='Refresh ARC' icon='refresh' requiresARC @clicked='refreshLocalArc()'></ToolbarButton>
+          <ToolbarButton text='Versioning' icon='mediation' requiresARC @clicked='AppProperties.state=AppProperties.STATES.GIT'></ToolbarButton>
           <ToolbarButton text='Explorer' icon='folder_open' requiresARC @clicked='ArcControlService.openArcInExplorer()'></ToolbarButton>
           <q-separator />
-
 
           <q-item class="col-grow"></q-item>
           <ToolbarButton text='Toggle Help' icon='help' @clicked='iProps.showHelp=!iProps.showHelp;'></ToolbarButton>

--- a/packages/renderer/src/AppProperties.ts
+++ b/packages/renderer/src/AppProperties.ts
@@ -34,6 +34,12 @@ const AppProperties: {
 
   user: null,
   path_sep: null,
+
+  datahub_hosts: [
+    'git.nfdi4plants.org',
+    'gitlab.nfdi4plants.de',
+    // 'gitlab.plantmicrobe.de'
+  ]
 });
 
 for(let k in AppProperties.STATES){

--- a/packages/renderer/src/ArcControlService.ts
+++ b/packages/renderer/src/ArcControlService.ts
@@ -31,11 +31,10 @@ function relativePath_to_absolute(relativePath: string) {
   return ArcControlService.props.arc_root + '/' + relativePath
 }
 
-
 const ArcControlService = {
-  
+
   props: reactive(init),
-  
+
   closeARC: async() => {
     ArcControlService.props.arc_root = null;
     ArcControlService.props.busy = false;
@@ -45,12 +44,11 @@ const ArcControlService = {
     AppProperties.state = 0;
     return;
   },
-  
+
   readARC: async (arc_root: string | void | null) =>{
-      if(!arc_root)
-      arc_root = ArcControlService.props.arc_root;
+    arc_root = arc_root || ArcControlService.props.arc_root;
     if(!arc_root)
-    return;
+      return;
 
     const isARC = await window.ipc.invoke('LocalFileSystemService.exists', arc_root+'/isa.investigation.xlsx');
 
@@ -176,7 +174,17 @@ const ArcControlService = {
     if(!arc_root)
       return;
     await window.ipc.invoke('LocalFileSystemService.openPath', arc_root);
+  },
+
+  updateARCfromFS: async ([path,type]) => {
+    // track add/rm assays/studies through file explorer
+    const requires_update = path.includes('isa.assay.xlsx') || path.includes('isa.study.xlsx');
+    if(!requires_update) return;
+
+    await ArcControlService.readARC();
   }
 };
+
+window.ipc.on('LocalFileSystemService.updatePath', ArcControlService.updateARCfromFS);
 
 export default ArcControlService;

--- a/packages/renderer/src/components/GitHistory.vue
+++ b/packages/renderer/src/components/GitHistory.vue
@@ -32,7 +32,7 @@ const getHistory = async ()=>{
 <template>
   <ViewItem
     icon="history"
-    label="History"
+    label="Log"
     caption="Inspect ARC history"
     group="git"
     @before-show='getHistory'

--- a/packages/renderer/src/components/GitPushPullForm.vue
+++ b/packages/renderer/src/components/GitPushPullForm.vue
@@ -1,0 +1,276 @@
+<script lang="ts" setup>
+
+import { onMounted, reactive } from 'vue';
+
+import ViewItem from '../components/ViewItem.vue';
+import a_checkbox from '../components/a_checkbox.vue';
+import a_btn from '../components/a_btn.vue';
+import ArcControlService from '../ArcControlService.ts';
+
+import AppProperties from '../AppProperties.ts';
+
+import AddRemoteDialog from '../dialogs/AddRemoteDialog.vue';
+import GitDialog from '../dialogs/GitDialog.vue';
+import { useQuasar } from 'quasar'
+const $q = useQuasar();
+
+const iProps = reactive({
+  git_status: [],
+  error: '',
+
+  lfs_pull: false,
+
+  remote: null,
+  remotes: {},
+
+  userListener: ()=>{}
+});
+
+const raiseError = err => {
+  iProps.error = err;
+  return false;
+};
+
+const getStatus = async()=>{
+  const response = await window.ipc.invoke('GitService.run', {
+    args: [`status`,`-z`,`-u`],
+    cwd: ArcControlService.props.arc_root
+  });
+  const status = response[1].split('\u0000').map(x => [x.slice(0,2),x.slice(3)]).slice(0,-1);
+  const sizes = await window.ipc.invoke('LocalFileSystemService.getFileSizes', status.map(x=> ArcControlService.props.arc_root +'/'+x[1]));
+  for(let i in sizes)
+    status[i].push(sizes[i]);
+  iProps.git_status = status;
+};
+
+const getBranches = async () => {
+  const response = await window.ipc.invoke('GitService.run', {
+    args: [`branch`],
+    cwd: ArcControlService.props.arc_root
+  });
+  const branches_raw = response[1].split('\n').slice(0,-1);
+  const branches = {
+    list: [],
+    current: null
+  };
+  for(let branch of branches_raw){
+    const branch_name = branch.slice(2);
+    branches.list.push(branch_name);
+    if(branch[0]==='*')
+      branches.current = branch_name;
+  }
+
+  return branches;
+};
+
+const patchRemote = async () => {
+  let response = null;
+
+  const remote = iProps.remote;
+  const remote_url = iProps.remotes[remote];
+
+  return AppProperties.user && remote_url.includes(AppProperties.user.host)
+    ? `https://oauth2:${AppProperties.user.token.access_token}@${AppProperties.user.host}` + remote_url.split(AppProperties.user.host)[1]
+    : remote_url;
+};
+
+const push = async()=>{
+  iProps.error = '';
+
+  if(!iProps.remote)
+    return raiseError('Pushing requires remote.');
+
+  if(!AppProperties.user)
+    return raiseError('Pushing requires login.');
+
+  await getStatus();
+  if(iProps.git_status.length>0)
+    return raiseError('Commit changes before pushing.');
+
+  const dialogProps = reactive({
+    title: 'Pushing ARC',
+    ok_title: 'Ok',
+    cancel_title: null,
+    state: 0,
+  });
+
+  $q.dialog({
+    component: GitDialog,
+    componentProps: dialogProps
+  });
+
+  let response = null;
+
+  // get current branch
+  const branches = await getBranches();
+  if(!branches.current) return dialogProps.state=2;
+
+  // patch remote
+  const patched_remote = await patchRemote();
+  if(!patched_remote) return dialogProps.state=2;
+
+  // push
+  response = await window.ipc.invoke('GitService.run', {
+    args: [`-c`,`core.askPass=true`,`push`,`--verbose`,`--atomic`,`--progress`,patched_remote,branches.current],
+    cwd: ArcControlService.props.arc_root
+  });
+
+  dialogProps.state=1;
+};
+
+const pull = async()=>{
+  iProps.error = '';
+
+  if(!iProps.remote)
+    return raiseError('Pulling requires remote.');
+
+  await getStatus();
+  if(iProps.git_status.length>0)
+    return raiseError('Commit changes before pulling.');
+
+  const dialogProps = reactive({
+    title: 'Pulling ARC',
+    ok_title: 'Ok',
+    cancel_title: null,
+    state: 0,
+  });
+
+  $q.dialog({
+    component: GitDialog,
+    componentProps: dialogProps
+  });
+
+  let response = null;
+
+  // get current branch
+  const branches = await getBranches();
+  if(!branches.current) return dialogProps.state=2;
+
+  // patch remote
+  const patched_remote = await patchRemote();
+  if(!patched_remote) return dialogProps.state=2;
+
+  // pull
+  response = await window.ipc.invoke('GitService.run', {
+    args: [`pull`,patched_remote,branches.current,'--progress'],
+    cwd: ArcControlService.props.arc_root
+  });
+  if(iProps.lfs_pull){
+    response = await window.ipc.invoke('GitService.run', {
+      args: [`lfs`,`pull`,patched_remote,branches.current],
+      cwd: ArcControlService.props.arc_root
+    });
+  }
+
+  dialogProps.state=1;
+};
+
+const getRemotes = async()=>{
+  const response = await window.ipc.invoke('GitService.run', {
+    args: [`remote`,`-v`],
+    cwd: ArcControlService.props.arc_root
+  });
+  iProps.remotes = {};
+  console.log(response);
+
+  for(let row of response[1].split('\n').slice(0,-1)){
+    const row_ = row.split('\t');
+    iProps.remotes[row_[0]] = row_[1].split(' ')[0];
+  }
+
+  iProps.remote = Object.keys(iProps.remotes)[0];
+};
+
+const init = async()=>{
+  iProps.error = '';
+  await getRemotes();
+};
+
+onMounted(()=>{
+  init();
+});
+
+const addRemote = e=>{
+  $q.dialog({
+    component: AddRemoteDialog,
+    componentProps: {
+      user: AppProperties.user,
+      remotes: Object.keys(iProps.remotes)
+    }
+  }).onOk( async data => {
+    await window.ipc.invoke('GitService.run', {
+      args: [`remote`,`add`,data.name,data.url],
+      cwd: ArcControlService.props.arc_root
+    });
+    await getRemotes();
+  });
+};
+
+const removeRemote = async remote=>{
+  await window.ipc.invoke('GitService.run', {
+    args: [`remote`,`remove`,remote],
+    cwd: ArcControlService.props.arc_root
+  });
+  getRemotes();
+};
+
+</script>
+
+<template>
+  <ViewItem
+    icon="wifi_protected_setup"
+    label="Push/Pull"
+    caption="Synchronize the ARC with a DataHub"
+    group="git"
+  >
+    <q-card flat>
+      <q-card-section>
+        <div class='row'>
+          <div class='col'>
+            <q-list class='bg-grey-3' dense style="border-radius:0.3em; margin:0.4em;">
+              <q-item-label style="padding:0.5em 1em;">Remote</q-item-label>
+
+              <q-item tag="label" v-ripple v-for='id of Object.keys(iProps.remotes)'>
+                <q-item-section side>
+                  <q-radio v-model='iProps.remote' :val='id' color='secondary' dense/>
+                </q-item-section>
+
+                <q-item-section no-wrap>
+                  <q-item-label>{{id}}</q-item-label>
+                  <q-item-label caption style="overflow:hidden;">
+                    {{iProps.remotes[id]}}
+                  </q-item-label>
+                </q-item-section>
+
+                <q-item-section side>
+                  <div class="text-grey-8 q-gutter-xs">
+                    <q-btn class="gt-xs" size="12px" flat dense round icon="delete" color='gray-7' @click='removeRemote(id)' />
+                  </div>
+                </q-item-section>
+              </q-item>
+
+              <q-item tag="label" v-ripple>
+                <q-item-section>
+                  <q-btn icon='add_circle' color='secondary' flat dense @click='addRemote' />
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='col'>
+            <a_checkbox v-model='iProps.lfs_pull' label="Use LFS" style="float:right;"/>
+          </div>
+        </div>
+
+      </q-card-section>
+
+      <q-card-actions align='right' style="padding:0 2.1em 1em 2.1em;">
+        <a_btn v-if='iProps.error' color="red-10" icon='warning' :label="iProps.error" no-caps style="margin-right:auto"/>
+        <a_btn label="Push" @click="push" icon='cloud_upload' :disabled='!iProps.remote || !AppProperties.user'/>
+        <a_btn label="Pull" @click="pull" icon='cloud_download' :disabled='!iProps.remote'/>
+      </q-card-actions>
+
+    </q-card>
+  </ViewItem>
+</template>

--- a/packages/renderer/src/components/SwateForm.vue
+++ b/packages/renderer/src/components/SwateForm.vue
@@ -42,13 +42,13 @@ const init = async ()=>{
   iProps.sheets = props.owner.Tables.map(t=>t.Name);
   iProps.active_sheet = props.owner.Tables.length ? props.owner.Tables[0].Name : null;
 
-  if(!iProps.templates){
-    const templates_json = await window.ipc.invoke('InternetService.getTemplates');
-    iProps.templates = await Templates_fromJsonString(JSON.stringify(templates_json));
-    console.log(iProps.templates);
+  // if(!iProps.templates){
+  //   const templates_json = await window.ipc.invoke('InternetService.getTemplates');
+    // iProps.templates = await Templates_fromJsonString(JSON.stringify(templates_json));
+    // console.log(iProps.templates);
     // for(let x of iProps.templates)
     //   console.log(x);
-  }
+  // }
 };
 
 onMounted( init );

--- a/packages/renderer/src/components/ViewItem.vue
+++ b/packages/renderer/src/components/ViewItem.vue
@@ -15,13 +15,19 @@ const props = defineProps<Props>();
 <template>
   <q-expansion-item
     expand-separator
-    :icon="props.icon"
-    :label="props.label"
-    :caption="props.caption"
-    header-class="bg-grey-33"
     :group='props.group'
     :default-opened='props.defaultOpened'
   >
+    <template v-slot:header>
+      <q-item-section avatar>
+        <q-icon color="grey-8" :name="props.icon" />
+      </q-item-section>
+
+      <q-item-section no-wrap>
+        <q-item-label>{{props.label}}</q-item-label>
+        <q-item-label caption>{{props.caption}}</q-item-label>
+      </q-item-section>
+    </template>
 
     <div v-if='props.fullWidth' style="display:block;margin:0 auto;">
       <slot></slot>

--- a/packages/renderer/src/components/a_btn.vue
+++ b/packages/renderer/src/components/a_btn.vue
@@ -1,0 +1,3 @@
+<template>
+  <q-btn color="secondary" />
+</template>

--- a/packages/renderer/src/components/a_checkbox.vue
+++ b/packages/renderer/src/components/a_checkbox.vue
@@ -1,0 +1,3 @@
+<template>
+  <q-checkbox v-bind="$attrs" color='secondary' dense filled style="padding:0.8em 1em 0 1em;" />
+</template>

--- a/packages/renderer/src/components/a_input.vue
+++ b/packages/renderer/src/components/a_input.vue
@@ -1,0 +1,3 @@
+<template>
+  <q-input v-bind="$attrs" dense filled style="padding:0.4em;" />
+</template>

--- a/packages/renderer/src/components/a_select.vue
+++ b/packages/renderer/src/components/a_select.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+
+export interface Props {
+  hint?: String
+};
+const props = withDefaults(defineProps<Props>(), {
+  hint: ''
+});
+</script>
+
+<template>
+  <q-select v-bind="$attrs" filled options-dense dense style="padding:0.4em;">
+    <template v-for="(_, name) in $slots" #[name]="slotProps">
+      <slot :name="name" v-bind="slotProps || {}"></slot>
+    </template>
+  </q-select>
+</template>

--- a/packages/renderer/src/dialogs/AddRemoteDialog.vue
+++ b/packages/renderer/src/dialogs/AddRemoteDialog.vue
@@ -1,0 +1,114 @@
+<script lang="ts" setup>
+import { reactive, onMounted } from 'vue';
+import { useDialogPluginComponent } from 'quasar';
+
+import a_input from '../components/a_input.vue';
+import a_select from '../components/a_select.vue';
+import ArcControlService from '../ArcControlService.ts';
+
+export interface Props {
+  remotes: [String],
+  user?: Object
+};
+const props = defineProps<Props>();
+
+const iProps = reactive({
+  mode: 'DataHub',
+  name: '',
+  account: '',
+  accounts: {},
+  url: '',
+  error: ''
+});
+
+const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent();
+
+const setDataHubURL = ()=>{
+  iProps.url = `https://${props.user.host}/${iProps.accounts[iProps.account]}/${ArcControlService.props.arc_root.split('/').pop().split(' ').join('_')}.git`;
+};
+
+const getAccounts = async (val, update, abort) => {
+  if(!props.user)
+    return update();
+
+  const groups = await window.ipc.invoke('DataHubService.getGroups', [props.user.host,props.user.token.access_token]);
+
+  update(()=>{
+    for(let group of groups)
+      iProps.accounts[group.full_name] = group.full_path;
+  });
+};
+
+const init = async ()=>{
+  if(props.remotes.indexOf('origin')<0)
+    iProps.name = 'origin';
+  else if (props.user && props.user.host && props.remotes.indexOf(props.user.host)<0)
+    iProps.name = props.user.host;
+  else
+    iProps.name = '';
+
+  if(props.user && props.user.host){
+    iProps.accounts[props.user.username] = props.user.username;
+    iProps.account = props.user.username;
+    setDataHubURL();
+  } else {
+    iProps.account = 'Login to use DataHub Account'
+  }
+};
+
+onMounted(init);
+
+const validName = val=>props.remotes.indexOf(val)<0;
+
+const onSubmit = async () => {
+  if (!iProps.name)
+    return iProps.error = 'Remote requires name';
+  else if (!validName(iProps.name))
+    return iProps.error = 'Remote name already exsists';
+  else if (!iProps.url)
+    return iProps.error = 'Remote requires URL';
+
+  onDialogOK(iProps);
+};
+
+</script>
+
+<template>
+  <q-form
+    @submit="onSubmit"
+  >
+    <q-dialog ref="dialogRef" persistent>
+      <q-card class="q-dialog-plugin" style="min-width:40em;">
+        <q-card-section>
+          <div class="text-h6">Add Remote</div>
+        </q-card-section>
+
+        <q-card-section>
+          <div class='row'>
+            <div class='col'>
+              <a_input
+                v-model='iProps.name'
+                label="Remote Name"
+              />
+            </div>
+            <div class='col'>
+              <a_select v-model='iProps.account' :options='Object.keys(iProps.accounts)' label="DataHub Account" :readonly='!props.user' @filter="getAccounts" @update:model-value='setDataHubURL()'/>
+            </div>
+          </div>
+          <div class='row'>
+            <div class='col'>
+              <a_input v-model='iProps.url' label="URL"/>
+            </div>
+          </div>
+        </q-card-section>
+
+        <q-card-actions align="right" style="margin:0 1.5em 1.5em;">
+          <q-btn v-if='iProps.error' color="red-10" icon='warning' :label="iProps.error" no-caps style="margin-right:auto"/>
+          <q-btn color="secondary" icon='add_circle' label="Add Remote" type='submit' class='text-weight-bold'/>
+          <q-btn color="secondary" label="Cancel" @click='onDialogCancel' class='text-weight-bold'/>
+        </q-card-actions>
+      </q-card>
+
+    </q-dialog>
+  </q-form>
+</template>

--- a/packages/renderer/src/dialogs/ErrorDialog.vue
+++ b/packages/renderer/src/dialogs/ErrorDialog.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { useDialogPluginComponent } from 'quasar';
+
+export interface Props {
+  error: String
+};
+const props = defineProps<Props>();
+
+const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent();
+
+</script>
+
+<template>
+
+  <q-dialog ref="dialogRef" persistent>
+    <q-card class="q-dialog-plugin">
+      <q-card-section>
+        <div class="text-h6">Error</div>
+      </q-card-section>
+
+      <q-card-section class="row no-wrap items-center" style="padding:0 0.2em;">
+        <q-icon class='col-grow' name="warning" color="grey-7" size="2em" style="padding:0 0.25em"/>
+        <div class="col">{{props.error}}</div>
+      </q-card-section>
+
+      <q-card-actions align="right" style="margin:0 1.5em 1.5em;">
+        <q-btn color="secondary" label="Ok" @click='onDialogOK' class='text-weight-bold'/>
+      </q-card-actions>
+    </q-card>
+
+  </q-dialog>
+</template>

--- a/packages/renderer/src/dialogs/ProgressDialog.vue
+++ b/packages/renderer/src/dialogs/ProgressDialog.vue
@@ -2,6 +2,8 @@
 import { useDialogPluginComponent } from 'quasar';
 import { reactive, onMounted } from 'vue';
 
+import a_btn from '../components/a_btn.vue';
+
 export interface Props {
   items: Array,
   title: String,
@@ -53,24 +55,13 @@ const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginC
           </q-item>
         </q-list>
 
-        <q-banner rounded inline-actions class="bg-red-10 text-white" dense v-if='props.error'>
-          <template v-slot:avatar>
-            <q-icon name="warning"/>
-          </template>
-          <div v-html='props.error'></div>
-        </q-banner>
-        <q-banner rounded inline-actions class="bg-secondary text-white" dense v-if='props.succ'>
-          <template v-slot:avatar>
-            <q-icon name="check_circle"/>
-          </template>
-          <div v-html='props.succ'></div>
-        </q-banner>
-
       </q-card-section>
 
       <q-card-actions align="right" style="margin:0 1.5em 1.5em;">
-        <q-btn color="secondary" :label="props.ok_title" @click="onDialogOK" type='submit' class='text-weight-bold' :disabled='!props.error && props.items[props.items.length-1][1]!==1'/>
-        <q-btn color="secondary" v-if='props.cancel_title' :label="props.cancel_title" @click="onDialogCancel" class='text-weight-bold' :disabled='props.items[props.items.length-1][1]<1'/>
+        <a_btn v-if='props.error' color="red-10" icon='warning' :label="iProps.error" no-caps style="margin-right:auto"/>
+        <a_btn v-if='props.succ' icon='check_circle' :label="props.succ" no-caps style="margin-right:auto"/>
+        <a_btn :label="props.ok_title" @click="onDialogOK" type='submit' :disabled='!props.error && props.items[props.items.length-1][1]!==1'/>
+        <a_btn v-if='props.cancel_title' :label="props.cancel_title" @click="onDialogCancel" :disabled='props.items[props.items.length-1][1]<1'/>
       </q-card-actions>
     </q-card>
 

--- a/packages/renderer/src/dialogs/SelectionDialog.vue
+++ b/packages/renderer/src/dialogs/SelectionDialog.vue
@@ -1,0 +1,55 @@
+<script lang="ts" setup>
+import { useDialogPluginComponent } from 'quasar';
+import { reactive, onMounted } from 'vue';
+
+import AppProperties from '../AppProperties.ts';
+
+export interface Props {
+  title: String,
+  value: String,
+  options: Array<String>,
+  label: String,
+  ok_label: String,
+  cancel_label: String
+};
+const props = withDefaults(defineProps<Props>(), {
+  title: 'TODO',
+  value: '',
+  options: [],
+  label: '',
+  ok_label: 'OK',
+  cancel_label: 'Cancel'
+});
+
+const iProps = reactive({
+  value: ''
+});
+
+defineEmits([
+  ...useDialogPluginComponent.emits
+]);
+
+const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent();
+
+onMounted(()=>iProps.value=props.value);
+
+</script>
+
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide" persistent>
+    <q-card class="q-dialog-plugin" style="min-width:45em;">
+      <q-card-section>
+        <div class="text-h6">{{props.title}}</div>
+      </q-card-section>
+
+      <q-card-section>
+        <q-select class='' v-model="iProps.value" :options="props.options" :label="props.label" dense/>
+      </q-card-section>
+
+      <q-card-actions align="right" style="margin:0 1.5em 1.5em;">
+        <q-btn color="secondary" :label="props.ok_label" @click='onDialogOK(iProps.value)' class='text-weight-bold' />
+        <q-btn color="secondary" :label="props.cancel_label" @click='onDialogCancel' class='text-weight-bold'/>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>

--- a/packages/renderer/src/dialogs/UserDialog.vue
+++ b/packages/renderer/src/dialogs/UserDialog.vue
@@ -1,0 +1,64 @@
+<script lang="ts" setup>
+import { useDialogPluginComponent } from 'quasar';
+import { reactive, onMounted } from 'vue';
+
+import AppProperties from '../AppProperties.ts';
+
+const iProps = reactive({
+  value: ''
+});
+
+defineEmits([
+  ...useDialogPluginComponent.emits
+]);
+
+const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } = useDialogPluginComponent();
+
+// onMounted(()=>iProps.value=props.value);
+
+</script>
+
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide" persistent>
+    <q-card class="q-dialog-plugin" style="min-width:45em;">
+      <q-card-section>
+        <div class="text-h6">User Information</div>
+      </q-card-section>
+
+      <q-card-section>
+        <q-list>
+          <q-item>
+            <q-item-section avatar>
+              <q-icon color="grey-7" name="account_circle" />
+            </q-item-section>
+            <q-item-section>
+              <q-input readonly label='Name' v-model='AppProperties.user.name' dense borderless />
+            </q-item-section>
+          </q-item>
+          <q-item>
+            <q-item-section avatar>
+              <q-icon color="grey-7" name="mail" />
+            </q-item-section>
+            <q-item-section>
+              <q-input readonly label='eMail' v-model='AppProperties.user.email' dense borderless />
+            </q-item-section>
+          </q-item>
+          <q-item>
+            <q-item-section avatar>
+              <q-icon color="grey-7" name="storage" />
+            </q-item-section>
+            <q-item-section>
+              <q-input readonly label='Host' v-model='AppProperties.user.host' dense borderless />
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+
+      <q-card-actions align="right" style="margin:0 1.5em 1.5em;">
+        <q-btn color="secondary" icon='logout' label="Logout" @click='onDialogOK' class='text-weight-bold' />
+        <q-btn color="secondary" label="Close" @click='onDialogCancel' class='text-weight-bold'/>
+      </q-card-actions>
+    </q-card>
+
+  </q-dialog>
+</template>

--- a/packages/renderer/src/views/ArcTreeView.vue
+++ b/packages/renderer/src/views/ArcTreeView.vue
@@ -331,35 +331,18 @@ const onSelectionChanged = id =>{
   }
 };
 
-const asyncDebounce = (mainFunction, delay) => {
-  // Declare a variable called 'timer' to store the timer ID
-  let timer: NodeJS.Timeout;
-
-  // Return an anonymous function that takes in any number of arguments
-  return function (...args) {
-    // Clear the previous timer to prevent the execution of 'mainFunction'
-    clearTimeout(timer);
-
-    // Set a new timer that will execute 'mainFunction' after the specified delay
-    timer = setTimeout(async () => {
-      await mainFunction(...args);
-    }, delay);
-  };
-};
-
-const debounceReadARC = asyncDebounce(ArcControlService.readARC, 300);
-
-const updatePath = async path => {
-  debounceReadARC();
+const updatePath = async ([path,type]) => {
   if (!arcTree.value)
     return;
-  const n = arcTree.value.getNodeByKey(path);
+
+  const parentPath = path.split('/').slice(0,-1).join('/');
+  const n = arcTree.value.getNodeByKey(parentPath);
   if(!n)
     return;
-  const isExpanded = arcTree.value.isExpanded(path);
+  const isExpanded = arcTree.value.isExpanded(parentPath);
   delete n.children;
   if(isExpanded)
-    arcTree.value.setExpanded(path,true);
+    arcTree.value.setExpanded(parentPath,true);
 };
 
 const formatSize = size => {

--- a/packages/renderer/src/views/DataHubView.vue
+++ b/packages/renderer/src/views/DataHubView.vue
@@ -22,13 +22,7 @@ const props = reactive({
   search_text: '',
   download_lfs: false,
   host: 'git.nfdi4plants.org',
-  hosts: [
-    'git.nfdi4plants.org',
-    'gitlab.nfdi4plants.de',
-    'gitlab.plantmicrobe.de'
-  ],
-
-  error: '',
+  error: ''
 });
 
 const inspectArc = url =>{
@@ -56,8 +50,8 @@ const importArc = async url =>{
     return;
 
   let url_with_credentials = url;
-  if(AppProperties.user && AppProperties.user.tokens[props.host])
-    url_with_credentials = url_with_credentials.replace('https://', `https://oauth2:${AppProperties.user.tokens[props.host].access_token}@`);
+  if(AppProperties.user && AppProperties.user.host===props.host)
+    url_with_credentials = url_with_credentials.replace('https://', `https://oauth2:${AppProperties.user.token.access_token}@`);
 
   const dialogProps = reactive({
     title: 'Downloading ARC',
@@ -107,8 +101,8 @@ const init = async () => {
     'DataHubService.getArcs',
     [
       props.host,
-      AppProperties.user && AppProperties.user.tokens[props.host]
-        ? AppProperties.user.tokens[props.host].access_token
+      AppProperties.user && AppProperties.user.host===props.host
+        ? AppProperties.user.token.access_token
         : null
     ]
   );
@@ -172,7 +166,7 @@ onUnmounted(async () => {
           </q-tooltip>
         </q-checkbox>
 
-        <q-select class='' v-model="props.host" :options="props.hosts" label="Host" dense/>
+        <q-select class='' v-model="props.host" :options="AppProperties.datahub_hosts" label="Host" dense/>
         <q-btn class='' label="" icon='refresh' color="secondary" @click='init()' no-wrap/>
       </div>
       <br>

--- a/packages/renderer/src/views/GitView.vue
+++ b/packages/renderer/src/views/GitView.vue
@@ -3,6 +3,7 @@
 import { onMounted, ref, reactive, watch } from 'vue';
 
 import GitCommitForm from '../components/GitCommitForm.vue';
+import GitPushPullForm from '../components/GitPushPullForm.vue';
 import GitHistory from '../components/GitHistory.vue';
 
 </script>
@@ -11,6 +12,8 @@ import GitHistory from '../components/GitHistory.vue';
 
   <q-list bordered class="rounded-borders">
     <GitCommitForm></GitCommitForm>
+    <q-separator />
+    <GitPushPullForm></GitPushPullForm>
     <q-separator />
     <GitHistory></GitHistory>
   </q-list>

--- a/packages/renderer/src/views/LoginView.vue
+++ b/packages/renderer/src/views/LoginView.vue
@@ -1,35 +1,69 @@
 <script lang="ts" setup>
 
+import {reactive} from 'vue';
+
 import ArcCommanderService from '../ArcCommanderService.ts';
+import AppProperties from '../AppProperties.ts';
+import SelectionDialog from '../dialogs/SelectionDialog.vue';
+import UserDialog from '../dialogs/UserDialog.vue';
+import ErrorDialog from '../dialogs/ErrorDialog.vue';
 
-import appProperties from '../AppProperties.ts';
-
-const showLoginView = ()=>{
-  window.ipc.invoke('DataHubService.authenticate', 'git.nfdi4plants.org');
-}
+import { useQuasar } from 'quasar'
+const $q = useQuasar();
 
 window.ipc.on('DataHubService.authentificationData', async user=>{
-  appProperties.user = user;
-
+  AppProperties.user = user;
 });
+
+const login = ()=>{
+  $q.dialog({
+    component: SelectionDialog,
+    componentProps: {
+      title: 'Please Select a DataHub',
+      value: AppProperties.datahub_hosts[0],
+      options: AppProperties.datahub_hosts,
+      label: 'Host',
+      ok_label: 'Login',
+      cancel_label: 'Cancel'
+    }
+  }).onOk( async host => {
+    const res = await window.ipc.invoke('DataHubService.authenticate', host);
+    if(res) return;
+
+    $q.dialog({
+      component: ErrorDialog,
+      componentProps: {
+        error: `Unable to authenticate at host "${host}"`,
+      }
+    });
+  });
+}
+
+const showUserData = ()=>{
+  $q.dialog({
+    component: UserDialog,
+  }).onOk( async ()=>{
+    AppProperties.user = null;
+  });
+}
 
 </script>
 
 <template>
 
-  <q-item v-if='!appProperties.user' clickable v-ripple @click='showLoginView'>
+  <q-item v-if='!AppProperties.user' clickable v-ripple @click='login'>
     <q-item-section avatar>
       <q-icon color='grey-7' name="exit_to_app"></q-icon>
     </q-item-section>
     <q-item-section style="margin-left:-1.2em;">Login</q-item-section>
   </q-item>
-  <q-item v-else clickable v-ripple>
+  <q-item v-else clickable v-ripple @click='showUserData'>
     <q-item-section avatar>
       <q-icon color='grey-7' name="account_circle"></q-icon>
     </q-item-section>
     <q-item-section style="margin-left:-1.2em;">
-      <q-item-label style="">{{appProperties.user.name}}</q-item-label>
-      <q-item-label caption style="font-size:0.8em;">{{appProperties.user.email}}</q-item-label>
+      <q-item-label style="">{{AppProperties.user.name}}</q-item-label>
+      <q-item-label caption style="font-size:0.8em;">{{AppProperties.user.host}}</q-item-label>
     </q-item-section>
   </q-item>
 


### PR DESCRIPTION
This PR is quite huge and therefore requires additional review (@Freymaurer). Creating separate PRs was not possible due to cross-dependencies.

Here is the description of the new features:
1. When users click on the `Login` button they will see the new `LoginDialog` that allows them to select the DataHub they wish to connect to.
2. The `DataHubService` now supports multiple hubs that use the same standardized GitLab API and oauth procedure.
3. The `GitView` now consists of separate components for performing commits (`GitCommitForm`), pushing/pulling from remotes (`GitPushPullForm`), and inspecting the git log (`GitHistory`).
4. The new `GitPushPullForm` makes it possible to add/remove remotes. Adding a remote is done through a new `AddRemoteDialog` that allows users to specify the name of the remote and the URL. If the user is logged in, then it is also possible to auto generate the URL from either the user account (e.g., `https://git.nfdi4plants.org/jonas/ArcPrototype.git`), or a group account (e.g., `https://git.nfdi4plants.org/ceplas/ArcPrototype.git`).
5. Previously it was possible to launch multiple git processes, which could lead to bugs due to interferences. Now the `GitService` enforces sequential execution of `GitService.run` commands through a queue.
6. Previously the `LocalFileSystemService` send only the parent path that needed to be updated when something was created/deleted. Now the `updatePath` signal sends the path to the actual file or directory instead of the parent path. Additionally, the signal also passes a second argument that reports the type of the update: `file_add`, `file_rm`,  `dir_add`, `dir_rm`.
7. Previously there existed a `LocalFileSystemService.updatePath` listener that triggered a `readARC` process every time the file system was updated. This was added to support the use case where users delete/add assays/studies through the file system instead of the ARCitect. This listener is now moved to the `ArcControlService` and only triggers a `readARC` if an `isa.assay/study.xlsx` file was added/removed.
8. As a first step away from `Property.ts` I added light-weight quasar component wrappers that follow this naming conversion: `q-some-quasar-component` -> `a_some-quasar-component`. Where possible we should use these new wrappers for uniformity.

