### PR TITLE
Implementation of PKCE authentification

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@quasar/vite-plugin": "^1.6.0",
+    "@types/express": "^4.17.21",
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "@vitejs/plugin-vue": "^5.0.2",
     "@vue/test-utils": "^2.4.3",

--- a/packages/main/src/DataHubService.d.ts
+++ b/packages/main/src/DataHubService.d.ts
@@ -1,0 +1,19 @@
+/** GitLab App authentication with Secret */
+type AuthWithSecret = {
+    id: string;
+    secret: string;
+};
+
+/** GitLab App authentication without Secret */
+type AuthIdOnly = {
+    id: string;
+    secret?: never;
+};
+  
+/** Store credetials for different datahubs. 
+Keys are adresses for the datahub.*/
+export interface Credentials {
+    [key : string] : AuthWithSecret | AuthIdOnly ;
+}
+  
+  

--- a/packages/main/src/DataHubService.d.ts
+++ b/packages/main/src/DataHubService.d.ts
@@ -16,4 +16,4 @@ export interface Credentials {
     [key : string] : AuthWithSecret | AuthIdOnly ;
 }
   
-  
+type User = {token: string; host: string}

--- a/packages/main/src/DataHubService.ts
+++ b/packages/main/src/DataHubService.ts
@@ -6,18 +6,15 @@ import {
 } from 'electron';
 
 import {InternetService} from '/@/InternetService';
-import {Credentials} from '/@/DataHubService.d';
+import {Credentials, User} from '/@/DataHubService.d';
 import { Request, Response } from 'express';
 import querystring from 'query-string';
 const express = require('express');
-//const crypto = require('crypto');
-//const { createHash } = require('crypto');
 import { createHash, randomInt} from 'crypto';
 let authApp = null;
 const authPort = 7890;
 
-type Host = string | null;
-type User = {token: string; host: string}
+
 
 // credentials for different repositories 
 // if secret is left out pkce will be used for authentification

--- a/packages/main/src/DataHubService.ts
+++ b/packages/main/src/DataHubService.ts
@@ -1,17 +1,24 @@
 import {
   ipcMain,
   BrowserWindow,
-  shell
+  shell,
+  IpcMainInvokeEvent,
 } from 'electron';
 
 import {InternetService} from '/@/InternetService';
-
+import {Credentials} from '/@/DataHubService.d';
+import { Request, Response } from 'express';
 import querystring from 'query-string';
 const express = require('express');
+const { createHash } = require('crypto');
+
 let authApp = null;
 const authPort = 7890;
 
-const CREDENTIALS = {
+type Host = string | null;
+type User = {token: string; host: string}
+
+const CREDENTIALS: Credentials = {
   'git.nfdi4plants.org': {
     id: 'af897fa1ef8474855feff07186adc6f26dee06971ee9ce4027f8f9c709a84c73',
     secret: 'd578e4df6370f219b9d55b04fbaf90315bdf655fb11405a16a43505c032650de',
@@ -29,8 +36,15 @@ const CREDENTIALS = {
 export const DataHubService = {
 
   auth_host: null,
+  code_verifier: '', 
+  code_challenge: '',
 
-  getPublicationByDOI: async (e,doi)=>{
+  generateCodeChallenge: (): void => {
+    DataHubService.code_verifier = 'oj23e9j93jd9w3j0d9cj9w3920r3f9j0f32j0923uf0923u0r9uw0fjw039fu0wf09wf'//window.crypto.randomUUID();
+    DataHubService.code_challenge = createHash('sha256').update(DataHubService.code_verifier).digest('base64url');
+  },
+
+  getPublicationByDOI: async (e: IpcMainInvokeEvent, doi: string ) => {
     return await InternetService.getWebPageAsJson(
       null,
       {
@@ -41,18 +55,18 @@ export const DataHubService = {
     );
   },
 
-  getPublicationByPubMedID: async (e,id)=>{
+  getPublicationByPubMedID: async ( e: IpcMainInvokeEvent, id: string ) => {
     return await InternetService.getWebPageAsJson(
       null,
       {
         host: 'api.ncbi.nlm.nih.gov',
-        path: '/lit/ctxp/v1/pubmed/?format=csl&id='+ id,
+        path: '/lit/ctxp/v1/pubmed/?format=csl&id=' + id,
         method: 'GET'
       }
     );
   },
 
-  getPersonByORCID: async (e,id)=>{
+  getPersonByORCID: async (e: IpcMainInvokeEvent, id: string)=>{
     return await InternetService.getWebPageAsJson(
       null,
       {
@@ -63,7 +77,7 @@ export const DataHubService = {
     );
   },
 
-  getArcs: async (e,[host,token])=>{
+  getArcs: async (e: IpcMainInvokeEvent, [host, token]:[string, string]) => {
     return await InternetService.getWebPageAsJson(
       null,
       {
@@ -74,52 +88,89 @@ export const DataHubService = {
     );
   },
 
-  inspectArc: async (e,url)=>{
+  inspectArc: async (e: IpcMainInvokeEvent, url: string) => {
     shell.openExternal(url);
     return;
   },
 
-  authenticate: async (e,host)=>{
+  authenticate: async (e: IpcMainInvokeEvent, host: any) => {
     if(!CREDENTIALS[host]) return false;
 
-    DataHubService.auth_host  = host;
-    const url_params = {
-      response_type: 'code',
-      redirect_uri: 'http://localhost:7890',
-      client_id: CREDENTIALS[host].id,
-      scope: `openid read_api email profile read_repository write_repository`
-    };
-    const auth_url = `https://${host}/oauth/authorize?${querystring.stringify(url_params)}`;
+    DataHubService.auth_host = host;
+    let auth_url = '';
+
+    if ('secret' in CREDENTIALS[host]) { 
+      const url_params = {
+        response_type: 'code',
+        redirect_uri: 'http://localhost:7890',
+        client_id: CREDENTIALS[host].id,
+        scope: `openid read_api email profile read_repository write_repository`
+      };
+      auth_url = `https://${host}/oauth/authorize?${querystring.stringify(url_params)}`;
+    } else {
+      DataHubService.generateCodeChallenge();
+      const url_params = {
+        response_type: 'code',
+        redirect_uri: 'http://localhost:7890',
+        client_id: CREDENTIALS[host].id,
+        scope: `openid read_api email profile read_repository write_repository`,
+        state: "stateshouldberandom",
+        code_challenge: DataHubService.code_challenge,
+        code_challenge_method:"S256"
+      };
+      auth_url = `https://${host}/oauth/authorize?${querystring.stringify(url_params)}`;
+      console.log(auth_url)
+    }
     shell.openExternal(auth_url);
+
+    //client_id=APP_ID&redirect_uri=REDIRECT_URI&response_type=code&state=STATE&scope=REQUESTED_SCOPES&code_challenge=CODE_CHALLENGE&code_challenge_method=S256
 
     return true;
   },
 
-  getToken: async (e,code,host)=>{
-    if(!CREDENTIALS[host]) return null;
+  getToken: async ( e: IpcMainInvokeEvent | null, code: string, host: string ) => {
+    console.log("get token");
+    if (!CREDENTIALS[host]) return null;
+    let path = '';
 
-    const url_params = {
-      code: code,
-      client_id: CREDENTIALS[host].id,
-      client_secret: CREDENTIALS[host].secret,
-      grant_type: 'authorization_code',
-      redirect_uri: 'http://localhost:7890'
-    };
+    if ('secret' in CREDENTIALS[host]) { 
+      const url_params = {
+        code: code,
+        client_id: CREDENTIALS[host].id,
+        client_secret: CREDENTIALS[host].secret,
+        grant_type: 'authorization_code',
+        redirect_uri: 'http://localhost:7890'
+      };
+      path = `/oauth/token?${querystring.stringify(url_params)}`;
+    } else {
+      console.log("without secret");
+      const url_params = {
+        code: code,
+        client_id: CREDENTIALS[host].id,
+        grant_type: 'authorization_code',
+        redirect_uri: 'http://localhost:7890',
+        code_verifier: DataHubService.code_verifier
+      };
+      path = `/oauth/token?${querystring.stringify(url_params)}`;
+      console.log(path)
+      //parameters = 'client_id=APP_ID&code=RETURNED_CODE&grant_type=authorization_code&redirect_uri=REDIRECT_URI&code_verifier=CODE_VERIFIER'
+      //RestClient.post 'https://gitlab.example.com/oauth/token', parameters
+    }
 
-    const path = `/oauth/token?${querystring.stringify(url_params)}`;
-
-    return await InternetService.getWebPageAsJson(
-        null,
-        {
-          host: host,
-          path: path,
-          port: 443,
-          method: 'POST'
-        }
-      );
+    let returnvalue = await InternetService.getWebPageAsJson(
+      null,
+      {
+        host: host,
+        path: path,
+        port: 443,
+        method: 'POST'
+      }
+    );
+    console.log(returnvalue);
+    return returnvalue
   },
 
-  getGroups: async (e,[host,token])=>{
+  getGroups: async ( e: IpcMainInvokeEvent, [host, token]: [string, string] ) => {
     return await InternetService.getWebPageAsJson(
         null,
         {
@@ -134,7 +185,7 @@ export const DataHubService = {
       );
   },
 
-  getUser: async (e,token,host)=>{
+  getUser: async ( e: IpcMainInvokeEvent | null, token: string, host: string ): Promise<User> => {
     return await InternetService.getWebPageAsJson(
         null,
         {
@@ -156,24 +207,39 @@ export const DataHubService = {
     ipcMain.handle('DataHubService.getPersonByORCID', DataHubService.getPersonByORCID );
 
     authApp = express()
-    authApp.get('/', async (req, res) => {
+    authApp.get('/', async (req: Request, res: Response) => {
+      console.log("redirect got called");
       if(!req.url || !req.url.startsWith('/?code=')){
+        console.log("inv request 1");
         return res.send('Invalid Request.');
+        
       }
 
-      const code = req.url.split('/?code=')[1];
-      const token = await DataHubService.getToken(null,code,DataHubService.auth_host);
-      const user = await DataHubService.getUser(null,token.access_token,DataHubService.auth_host);
+      if(DataHubService.auth_host === null){
+        console.log("inv request 2");
+        return res.send('Invalid Request.');
+      }
+      
+      const code = req.url.split('/?code=')[1].split('&')[0];
+      console.log(code)
+      const token = await DataHubService.getToken(null, code, DataHubService.auth_host);
+      const user = await DataHubService.getUser(null, token.access_token, DataHubService.auth_host);
       user.token = token;
       user.host = DataHubService.auth_host;
 
       res.send('<h1>Login and Authorization Complete. You can now return to ARCitect.</h1><script>window.close()</script>');
       let window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
-      window.webContents.send('DataHubService.authentificationData', user);
-      window.focus();
+      
+      if( window !== undefined){
+        window.webContents.send('DataHubService.authentificationData', user);
+        window.focus();
+      }
+
     });
     authApp.listen(authPort, () => {
       console.log(`Authentification service listening on port ${authPort}`);
+      
+      console.log(DataHubService.code_challenge);
     });
   }
 

--- a/packages/main/src/InternetService.ts
+++ b/packages/main/src/InternetService.ts
@@ -16,7 +16,7 @@ const default_header = {
 
 export const InternetService = {
 
-  getWebPageAsJson: (e,options) => {
+  getWebPageAsJson: (e,options): Promise<any> => {
     return new Promise(
       (resolve, reject) => {
         try {


### PR DESCRIPTION
In the current version of ARCitect client ids and secrets have to be stored in code. It would be nice to avoid storing the secrets in code. This can be avoided by using [PKCE flow](https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-with-proof-key-for-code-exchange-pkce). Here I implemented this in DataHubService.ts.

The PKCE will be used if a datahub entry in Credentials does not contain a "secret" field.:
- on authorization the existence of secret field is checked 
- if not existing the strings: state, code_verifier and code_challenge are generated
- code request is done with code_challenge instead of client secret
- subsequently token request is done with code_verifier

---
The previous authentification method is still possible

pkce will only work if confidential is turned off - and I assume that then client_id/ client_secret method will not work anymore.

![image](https://github.com/nfdi4plants/ARCitect/assets/402960/1a6f5b05-3f14-47a2-87f7-8ce416bcfaa1)

---
Not thouroughly tested. But from receving the token/refresh token everything should be the same as before.