### PR TITLE
Replace broken link to tutorials

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -74,7 +74,7 @@ export async function restoreOrCreateWindow() {
         {
           label: 'Tutorials',
           click: async () => {
-            shell.openExternal('https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/tutorials/QuickStart_swate.html');
+            shell.openExternal('https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/guides/arcitect_QuickStart.html');
           }
         },
         {


### PR DESCRIPTION
I noticed that the link for "Tutorials" in the Help menu was broken (404 page). Updated it to the ARCitect Quickstart page