### PR TITLE
automatically save changes in Markdown editor when switching files

### DIFF
--- a/packages/renderer/src/views/MarkdownView.vue
+++ b/packages/renderer/src/views/MarkdownView.vue
@@ -183,8 +183,12 @@ onMounted(async ()=>{
 onUnmounted(()=>{
   observer.disconnect();
   iProps.container.removeEventListener("click", iProps.link_listener);
+  window.ipc.invoke('LocalFileSystemService.writeFile', [iProps.path,iProps.text || ' ']);
 });
-watch( ()=>AppProperties.active_markdown, init );
+watch(() => AppProperties.active_markdown, async (newPath, oldPath) => {
+  window.ipc.invoke('LocalFileSystemService.writeFile', [oldPath, iProps.text || ' ']);
+  await init(); // Load new file
+});
 
 </script>
 


### PR DESCRIPTION
This should resolve #428 . Of course auto-saving is a bit opinionated but it's in line with the current behavior for ISA files and much better than what we have now.