### PR TITLE
Apply LFS blacklist as intended for ISA files

### DIFF
--- a/packages/renderer/src/GitService.ts
+++ b/packages/renderer/src/GitService.ts
@@ -44,11 +44,14 @@ const GitService = {
     }
   }),
 
-  is_not_lfs_blacklisted: id=>
-       !GitService._.lfs_blacklist.starts.some(i=>id.startsWith(i))
-    && !GitService._.lfs_blacklist.ends.some(i=>id.endsWith(i))
-    && !GitService._.change_tree_map.get(id).types.includes('D')
-  ,
+  is_not_lfs_blacklisted: id=>{
+    const filename = id.replace(/\\/g, '/').split('/').pop();
+    return (
+      !GitService._.lfs_blacklist.starts.some(i=>filename.startsWith(i)) &&
+      !GitService._.lfs_blacklist.ends.some(i=>filename.endsWith(i)) &&
+      !GitService._.change_tree_map.get(id).types.includes('D')
+    );
+  },
 
   get_leaf_nodes: (nodes,node) => {
     node = node || GitService._.change_tree[0];


### PR DESCRIPTION
This should resolve #453 and resolve #431. It was actually already in the code since last June but because it was looking at the full path and not the filename it didn't recognize "assays/foobar/isa.assay.xlsx" as starting with "isa." 🤣