### PR TITLE
add image metadata browser to image view component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@quasar/extras": "^1.16.9",
     "chokidar": "^3.5.3",
     "electron-context-menu": "^3.6.1",
+    "exifreader": "^4.33.1",
     "express": "^4.18.2",
     "fs-extra": "^11.2.0",
     "image-type": "^5.2.0",
@@ -50,7 +51,8 @@
     "quasar": "^2.14.2",
     "query-string": "^8.1.0",
     "vue": "^v3.4.5",
-    "vue3-markdown": "^1.2.12"
+    "vue3-markdown": "^1.2.12",
+    "xmldom": "^0.6.0"
   },
   "devDependencies": {
     "@quasar/vite-plugin": "^1.10.0",

--- a/packages/renderer/src/views/ArcTreeView.vue
+++ b/packages/renderer/src/views/ArcTreeView.vue
@@ -13,7 +13,7 @@ import AddProtocolDialog from '../dialogs/AddProtocolDialog.vue';
 import ProgressDialog from '../dialogs/ProgressDialog.vue';
 import { useDownloadLFSFiles } from '../composables/useDownloadLFSFiles';
 import { useQuasar } from 'quasar'
-import {ArcStudy, ArcAssay, ArcRun, ArcWorkflow, DataMap as ArcDatamap, ArcInvestigation, ARC} from '@nfdi4plants/arctrl';
+import {ArcStudy, ArcAssay, ArcRun, ArcWorkflow, Datamap as ArcDatamap, ArcInvestigation, ARC} from '@nfdi4plants/arctrl';
 import { setAssayIdentifier, setRunIdentifier, setStudyIdentifier, setWorkflowIdentifier } from "@nfdi4plants/arctrl/Core/IdentifierSetters";
 import IdentifierDialog from '../dialogs/IdentifierDialog.vue';
 import {type LFSJsonFile} from '../GitService';

--- a/packages/renderer/src/views/ImageView.vue
+++ b/packages/renderer/src/views/ImageView.vue
@@ -7,12 +7,43 @@ import ViewItem from '../components/ViewItem.vue';
 
 const iProps = reactive({
   image: '',
+  metadata: {},
+  metadataDirectories: [] as { key: string, value: string }[],
+  splitterModel: 60
 });
 
-const init = async ()=>{
-  if(!AppProperties.active_image) return;
-  iProps.image = await window.ipc.invoke('LocalFileSystemService.readImage', AppProperties.active_image);
+const init = async () => {
+  if (!AppProperties.active_image) return;
+
+  const result = await window.ipc.invoke(
+    'LocalFileSystemService.readImage',
+    AppProperties.active_image
+  );
+
+  if (!result) return;
+
+  iProps.image = result.dataUrl;
+  iProps.metadata = result.metadata || {};
+
+  // Holds one entry per metadata directory in the image
+  const dirs: Record<string, any[]> = {};
+
+  for (const [dirName, tags] of Object.entries(iProps.metadata)) {
+    if (!tags || typeof tags !== 'object') continue;
+
+    // Convert directory entries into table rows
+    dirs[dirName] = Object.entries(tags).map(([tagName, tagValue]: any) => ({
+      key: tagName,
+      value:
+        typeof tagValue?.description !== 'undefined'
+          ? String(tagValue.description)
+          : JSON.stringify(tagValue)
+    }));
+  }
+
+  iProps.metadataDirectories = dirs;
 };
+
 
 onMounted(init);
 watch( ()=>AppProperties.active_image, init );
@@ -20,13 +51,72 @@ watch( ()=>AppProperties.active_image, init );
 </script>
 
 <template>
-  <q-list>
-    <ViewItem
-      icon="photo_library"
-      label="Image Preview"
-      :caption="AppProperties.active_image"
-    >
-      <img v-if='AppProperties.active_image' :src='iProps.image' style="width:100%;"/>
-    </ViewItem>
-  </q-list>
+  <!-- Horizontal splitter: top = before (image), bottom = after (metadata) -->
+  <q-splitter
+    horizontal
+    v-model=iProps.splitterModel
+    style="height:100%;"
+    :limits="[20, 80]"
+  >
+    <!-- TOP: image preview (before slot) -->
+    <template #before>
+      <div style="display:flex; flex-direction:column; height:100%;">
+        <ViewItem
+          icon="photo_library"
+          label="Image Preview"
+          :caption="AppProperties.active_image"
+          style="flex:1 1 auto;"
+        >
+          <img
+            v-if="AppProperties.active_image"
+            :src="iProps.image"
+            style="width:100%; height:100%; object-fit:contain;"
+          />
+        </ViewItem>
+      </div>
+    </template>
+
+    <!-- BOTTOM: metadata (after slot) -->
+    <template #after>
+      <div style="overflow:auto; padding:8px;">
+        <ViewItem
+          v-if="iProps.metadataDirectories && Object.keys(iProps.metadataDirectories).length"
+          icon="dataset"
+          label="Image Metadata"
+          caption="EXIF / XMP Metadata"
+          class="text-subtitle1"
+        >
+          <q-expansion-item
+            v-for="(rows, dirName) in iProps.metadataDirectories"
+            icon="image_search"
+            :key="dirName"
+            :label="dirName"
+            header-class="text-subtitle2 text-uppercase"
+            dense
+            expand-separator
+            :default-opened="dirName.toLowerCase().includes('exif')" 
+            
+          >
+            <div style="overflow-x:auto;">
+              <q-table
+                :rows="rows"
+                :columns="[
+                  { name: 'key', label: 'Key', field: 'key', align: 'left', style: 'width:200px;' },
+                  { name: 'value', label: 'Value', field: 'value', align: 'left' }
+                ]"
+                row-key="key"
+                bordered
+                dense
+              />
+            </div>
+          </q-expansion-item>
+        </ViewItem>
+
+        <!-- optional: show a message when no metadata -->
+        <div v-else style="padding: 12px; color:var(--q-color-grey-6);">
+          No metadata available.
+        </div>
+      </div>
+    </template>
+  </q-splitter>
 </template>

--- a/packages/renderer/src/views/SwateView.vue
+++ b/packages/renderer/src/views/SwateView.vue
@@ -4,7 +4,7 @@ import ArcControlService from '../ArcControlService.ts';
 import AppProperties from '../AppProperties.ts';
 import SwateControlService from '../SwateControlService.ts';
 import * as SCS from '../SwateControlService.ts';
-import { ArcInvestigation, ArcAssay, ArcStudy, JsonController, type Person, ArcRun, ArcWorkflow, ARC, DataMap as ArcDatamap } from '@nfdi4plants/arctrl';
+import { ArcInvestigation, ArcAssay, ArcStudy, JsonController, type Person, ArcRun, ArcWorkflow, ARC, Datamap as ArcDatamap } from '@nfdi4plants/arctrl';
 import { ARCtrl_Person__Person_toJsonString_71136F3F as personToJson } from '@nfdi4plants/arctrl/JsonIO/Person'
 
 import a_btn from '../components/a_btn.vue';


### PR DESCRIPTION
This PR
- updates the imports of `Datamap` from arctrl (was previously named `DataMap`)
- Adds 2 new dependencies for image metadata extraction
    - exifreader
    - xmldom
- Adds functionality to extract image metadata to the `readFile` service provided in `LocalFileSystemService.ts`
- Adds image metadata directory browser components to `ImageView.vue`

