### PR TITLE
Improve error handling for ARC opening failures and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ where applicable. Add your name in the style of `(by @github-username)` at the e
 ### 🐛 Fixed
 
 - Datamap imports from arctrl spelling (older versions had capitalized M) (by @kMutagene)
+- ARC open failures now show detailed errors and release the loading overlay correctly (by @caroott)
 
 ## 1.4.0 - 2025-12-03
 

--- a/packages/renderer/src/App.vue
+++ b/packages/renderer/src/App.vue
@@ -61,9 +61,16 @@ const openLocalArc = async (path: string | null | void) =>{
 
   AppProperties.state=AppProperties.STATES.HOME;
 
-  let isOpen = await ArcControlService.readARC(path);
-  if(!isOpen){
-    iProps.error_text = 'Invalid ARC format:<br>'+path;
+  try {
+    const isOpen = await ArcControlService.readARC(path);
+    if(!isOpen){
+      iProps.error_text = 'Invalid ARC format:<br>'+path;
+      iProps.error = true;
+      return;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    iProps.error_text = 'Failed to open ARC:<br>'+message;
     iProps.error = true;
     return;
   }


### PR DESCRIPTION
Ensure ARC open errors surface while the loading overlay always clears; added try/catch for the open flow and try/finally in `readARC`