### PR TITLE
Improvements to 'out of sync' notifications

### DIFF
--- a/packages/renderer/src/App.vue
+++ b/packages/renderer/src/App.vue
@@ -262,7 +262,7 @@ onMounted(async () => {
           position: 'bottom-left',
           timeout: 0,
           actions: [
-            { label: 'X', color: 'white', handler: () => {} }
+            { label: 'X', color: 'white', handler: () => { dirtyRemoteNotification = null; } }
           ]
         });
       } else if (oldVal && !newVal && dirtyRemoteNotification) {


### PR DESCRIPTION
(re #469 ). 

- I noticed dirty_remote also triggers when there are un-pushed changes so I adapted the wording of the notification
- the notification now also disappears on its own after syncing
- when opening an ARC without being logged in, there is a temporary (5sec, info) notification that you need to login in order to sync changes

After we're through with this PR and #481, perhaps we can try a pre-release to get all this on the way to the users? 🙂