### PR TITLE
consistent collapse toggling for ISA objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ where applicable. Add your name in the style of `(by @github-username)` at the e
 
 ## [Unreleased]
 
+### 🔄 Changed
+
+- Toggle tree collapse when clicking on the name of a study, assay, workflow, or run (by @Thyra).
+
 ## 1.6.1 - 2026-03-04
 
 ### 🐛 Fixed

--- a/packages/renderer/src/views/ArcTreeView.vue
+++ b/packages/renderer/src/views/ArcTreeView.vue
@@ -422,19 +422,15 @@ const triggerNode = (e: any, node: ArcTreeViewNode) => {
       props.selection = node.id;
       return SwateControlService.LoadSwateState(SCS.Type.ArcInvestigation);
     case formatNodeEditString(Studies):
-      skip(e);
       props.selection = node.id;
       return SwateControlService.LoadSwateState(1,node.label);
     case formatNodeEditString(Assays):
-      skip(e);
       props.selection = node.id;
       return SwateControlService.LoadSwateState(2,node.label);
     case formatNodeEditString(Runs):
-      skip(e);
       props.selection = node.id;
       return SwateControlService.LoadSwateState(3,node.label);
     case formatNodeEditString(Workflows):
-      skip(e);
       props.selection = node.id;
       return SwateControlService.LoadSwateState(4,node.label);
     case formatNodeEditString(Markdown):


### PR DESCRIPTION
A user had a somewhat silly problem but with a trivial fix: they didn't know they could/had to un-collapse an assay to see the underlying dataset folders etc. ("I'm making an ARC but I can't find where to actually put my data"). The issue was that they didn't intuitively understand the little `>` symbol next to the assay name as something actionable since everything else in ARCitect also opens/closes by just clicking on the name. So this tiny PR makes things consistent and also applies this behavior to assays, studies, workflows, and runs.